### PR TITLE
Removes ShimGen created win32yank, tee, etc

### DIFF
--- a/neovim/neovim.nuspec
+++ b/neovim/neovim.nuspec
@@ -27,7 +27,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>0.2.2.20180416</version>
+    <version>0.2.2.20180418</version>
 		<packageSourceUrl>https://github.com/rmolin88/choco-neovim</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
 		<owners>Bart Joy, Reinaldo Molina</owners>
@@ -63,7 +63,14 @@ GUIs (or TUIs—such as readline) can nvim --embed or communicate via TCP socket
 # Drop-in replacement for Vim
 Neovim is an extension of Vim: feature-parity and backwards compatibility are high priorities. If you are already familiar with Vim, see :help nvim-from-vim to learn about the differences.
 		</description>
-    <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
+        <releaseNotes>
+# Package-Fix Release Notes
+
+## 0.2.2.20180418
+
+  * FIX: Resolves rmolin88/choco-neovim/issues/#6, Invoking ShimGen version of win32yank.exe leaves dangling consoles (Introduced in 0.2.2.20180418)
+
+        </releaseNotes>
     <!-- =============================== -->      
 
     <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->

--- a/neovim/tools/chocolateyinstall.ps1
+++ b/neovim/tools/chocolateyinstall.ps1
@@ -22,18 +22,6 @@ $packageArgs = @{
 
 $nvim = $destDir + '\Neovim\bin\nvim-qt.exe'
 Install-BinFile -Name 'nvim-qt' -Path $nvim -UseStart true
-$tee = $destDir + "\Neovim\bin\tee.exe"
-Install-BinFile -Name 'tee' -Path $tee
-$tidy = $destDir + "\Neovim\bin\tidy.exe"
-Install-BinFile -Name 'tidy' -Path $tidy
-$winYank = $destDir + "\Neovim\bin\win32yank.exe"
-Install-BinFile -Name 'win32yank' -Path $winYank
-$agent = $destDir + "\Neovim\bin\winpty-agent.exe"
-Install-BinFile -Name 'winpty-agent' -Path $agent
-$cat = $destDir + "\Neovim\bin\cat.exe"
-Install-BinFile -Name 'cat' -Path $cat
-$diff = $destDir + "\Neovim\bin\diff.exe"
-Install-BinFile -Name 'diff' -Path $diff
 $exe = $destDir + "\Neovim\bin\nvim.exe"
 Install-BinFile -Name 'nvim' -Path $exe
 


### PR DESCRIPTION
Fixes rmolin88/choco-neovim/issues/6 by removing the ShimGen created tee, tidy, win32yank, winpty-agent, cat, and diff binaries.

The ShimGen binaries cause problems with Neovim. For example, adding a ShimGen generated `win32yank` leaves danging windows open after every yank/paste operation when `clipboard+=unnamedplus` is set.

There shouldn't be any issues adding a ShimGen for `nvim-qt.exe`. It's possible that calling `nvim.exe` from other applications could cause similar issues.