### PR TITLE
Allow installation of neovim for all users

### DIFF
--- a/neovim-git/neovim.nuspec
+++ b/neovim-git/neovim.nuspec
@@ -27,7 +27,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-		<version>0.4.5-beta</version>
+		<version>0.4.5.20210116-beta</version>
 		<packageSourceUrl>https://github.com/rmolin88/choco-neovim</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
 		<owners>Reinaldo Molina</owners>

--- a/neovim-git/neovim.nuspec
+++ b/neovim-git/neovim.nuspec
@@ -71,11 +71,18 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
 - For example: `choco install neovim --pre`. 
 - Which will get you the latest _nightly_ builds for windows.
 
-### Package Parametes
+### Package Parameters
 - `/NoNeovimOnPath`: Neovim binary folder will not be added to the path.
 - Optional parameter.
 - Default behavior is that Neovim binary will be added to the path.
 - Example: `choco install neovim --params "/NoNeovimOnPath"`
+			
+- `/AddToAllUserPath`: Neovim binary folder will be added to the machine path.
+- Optional parameter.
+- Default behavior is that Neovim binary will be added only to the users path.
+- If this is used together with `/NoNeovimOnPath`, this takes precedence and the path will be modified.
+- Example: `choco install neovim --params "/AddToAllUserPath"`
+
 
 **Note:** To force the installation of x32 version, use the `--x86` argument with `choco install`.
 

--- a/neovim-git/neovim.nuspec
+++ b/neovim-git/neovim.nuspec
@@ -65,7 +65,6 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
 - Neovim is an extension of Vim: feature-parity and backwards compatibility are high priorities.
 - If you are already familiar with Vim, see :help nvim-from-vim to learn about the differences.
 
-
 ### Following HEAD
 - If you want to stay up to date with the latest development you can install neovim using the `--pre` option.
 - For example: `choco install neovim --pre`. 
@@ -75,14 +74,13 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
 - `/NoNeovimOnPath`: Neovim binary folder will not be added to the path.
 - Optional parameter.
 - Default behavior is that Neovim binary will be added to the path.
+- If this is used together with `/NeovimOnPathForAll`, this takes precedence and the path will not be modified.
 - Example: `choco install neovim --params "/NoNeovimOnPath"`
-			
-- `/AddToAllUserPath`: Neovim binary folder will be added to the machine path.
+
+- `/NeovimOnPathForAll`: Neovim binary folder will be added to the machine path.
 - Optional parameter.
 - Default behavior is that Neovim binary will be added only to the users path.
-- If this is used together with `/NoNeovimOnPath`, this takes precedence and the path will be modified.
-- Example: `choco install neovim --params "/AddToAllUserPath"`
-
+- Example: `choco install neovim --params "/NeovimOnPathForAll"`
 
 **Note:** To force the installation of x32 version, use the `--x86` argument with `choco install`.
 

--- a/neovim-git/tools/chocolateyinstall.ps1
+++ b/neovim-git/tools/chocolateyinstall.ps1
@@ -42,7 +42,7 @@ Install-ChocolateyZipPackage @packageArgs
 if ($pp['AddToAllUserPath']) {
 	Install-ChocolateyPath -PathToInstall $bin -PathType Machine
         Write-Output "Added Neovim binary folder to the machines's PATH variable"
-} else if (!$pp['NoNeovimOnPath']) {
+} elseif (!$pp['NoNeovimOnPath']) {
 	Install-ChocolateyPath -PathToInstall $bin
         Write-Output "Added Neovim binary folder to the user's PATH variable"
 } else {

--- a/neovim-git/tools/chocolateyinstall.ps1
+++ b/neovim-git/tools/chocolateyinstall.ps1
@@ -39,10 +39,12 @@ Install-ChocolateyZipPackage @packageArgs
 
 # Adds neovim to the path if not present already
 # Define option here and check at the same time
-if (!$pp['NoNeovimOnPath']) {
+if ($pp['AddToAllUserPath']) {
+	Install-ChocolateyPath -PathToInstall $bin -PathType Machine
+        Write-Output "Added Neovim binary folder to the machines's PATH variable"
+} else if (!$pp['NoNeovimOnPath']) {
 	Install-ChocolateyPath -PathToInstall $bin
         Write-Output "Added Neovim binary folder to the user's PATH variable"
-
 } else {
         Write-Output "Please note that Neovim binary folder will NOT be added to the path"
 }

--- a/neovim-git/tools/chocolateyinstall.ps1
+++ b/neovim-git/tools/chocolateyinstall.ps1
@@ -1,8 +1,8 @@
 ﻿# File:           chocolateyinstall.ps1
-# Description:    Installation of neovim
-# Author:		    Reinaldo Molina
+# Description:    Installation of Neovim
+# Author:         Reinaldo Molina
 # Email:          rmolin88 at gmail dot com
-# Revision:	    0.0.0
+# Revision:       0.0.0
 # Last Modified:  Fri Apr 20 2018 22:47
 
 $ErrorActionPreference = 'Stop'; # stop on all errors
@@ -17,21 +17,20 @@ $bin         = $destDir + '\Neovim\bin'
 # Help here: https://github.com/chocolatey/choco/wiki/HelpersGetPackageParameters
 $pp = Get-PackageParameters
 
-# Write-Output $destDir
 $packageArgs = @{
-	packageName   = $packageName
-	unzipLocation = $destDir
-	url           = $url
-	url64bit      = $url64
+    packageName   = $packageName
+    unzipLocation = $destDir
+    url           = $url
+    url64bit      = $url64
 
-	softwareName  = 'neovim*' #part or all of the Display Name as you see it in Programs and Features. It should be enough to be unique
+    softwareName  = 'neovim*' #part or all of the Display Name as you see it in Programs and Features. It should be enough to be unique
 
-	checksum      = ''
-	checksumType  = 'sha256' #default is md5, can also be sha1, sha256 or sha512
-	checksum64    = ''
-	checksumType64= 'sha256' #default is checksumType
+    checksum      = ''
+    checksumType  = 'sha256' #default is md5, can also be sha1, sha256 or sha512
+    checksum64    = ''
+    checksumType64= 'sha256' #default is checksumType
 
-	validExitCodes= @(0) #please insert other valid exit codes here
+    validExitCodes= @(0) #please insert other valid exit codes here
 }
 
 # https://chocolatey.org/docs/helpers-install-chocolatey-package
@@ -39,14 +38,14 @@ Install-ChocolateyZipPackage @packageArgs
 
 # Adds neovim to the path if not present already
 # Define option here and check at the same time
-if ($pp['AddToAllUserPath']) {
-	Install-ChocolateyPath -PathToInstall $bin -PathType Machine
-        Write-Output "Added Neovim binary folder to the machines's PATH variable"
-} elseif (!$pp['NoNeovimOnPath']) {
-	Install-ChocolateyPath -PathToInstall $bin
-        Write-Output "Added Neovim binary folder to the user's PATH variable"
+if ($pp['NoNeovimOnPath']) {
+    Write-Output "Please note that Neovim binary folder will NOT be added to the path"
+} elseif (!$pp['NeovimOnPathForAll']) {
+    Install-ChocolateyPath -PathToInstall $bin -PathType Machine
+    Write-Output "Added Neovim binary folder to the machines's PATH variable"
 } else {
-        Write-Output "Please note that Neovim binary folder will NOT be added to the path"
+    Install-ChocolateyPath -PathToInstall $bin
+    Write-Output "Added Neovim binary folder to the user's PATH variable"
 }
 
 Write-Output "Please Consider donating https://salt.bountysource.com/teams/neovim"

--- a/neovim-git/tools/chocolateyinstall.ps1
+++ b/neovim-git/tools/chocolateyinstall.ps1
@@ -40,7 +40,7 @@ Install-ChocolateyZipPackage @packageArgs
 # Define option here and check at the same time
 if ($pp['NoNeovimOnPath']) {
     Write-Output "Please note that Neovim binary folder will NOT be added to the path"
-} elseif (!$pp['NeovimOnPathForAll']) {
+} elseif ($pp['NeovimOnPathForAll']) {
     Install-ChocolateyPath -PathToInstall $bin -PathType Machine
     Write-Output "Added Neovim binary folder to the machines's PATH variable"
 } else {

--- a/neovim-git/tools/chocolateyuninstall.ps1
+++ b/neovim-git/tools/chocolateyuninstall.ps1
@@ -9,4 +9,4 @@ $packageName= 'neovim' # arbitrary name for the package, used in messages
 $destDir = Join-Path $(Get-ToolsLocation) $packageName
 $bin         = $destDir + '\Neovim\bin'
 
-Write-Output "Please manually remove `"$($bin)`" from the User PATH environment variable if not installing neovim again."
+Write-Output "Please manually remove `"$($bin)`" from the PATH environment variable if not installing neovim again."

--- a/neovim/neovim.nuspec
+++ b/neovim/neovim.nuspec
@@ -74,12 +74,12 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
 - `/NoNeovimOnPath`: Neovim binary folder will not be added to the path.
 	- Optional parameter.
 	- Default behavior is that Neovim binary will be added to the users path.
+	- If this is used together with `/NeovimOnPathForAll`, this takes precedence and the path will not be modified.
 	- Example: `choco install neovim --params "/NoNeovimOnPath"`
-- `/AddToAllUserPath`: Neovim binary folder will be added to the machine path.
+- `/NeovimOnPathForAll`: Neovim binary folder will be added to the machine path.
 	- Optional parameter.
 	- Default behavior is that Neovim binary will be added only to the users path.
-	- If this is used together with `/NoNeovimOnPath`, this takes precedence and the path will be modified.
-	- Example: `choco install neovim --params "/AddToAllUserPath"`
+	- Example: `choco install neovim --params "/NeovimOnPathForAll"`
 
 **Note:** To force the installation of x32 version, use the --x86 argument with `choco install`.
 

--- a/neovim/neovim.nuspec
+++ b/neovim/neovim.nuspec
@@ -27,7 +27,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>0.4.4</version>
+    <version>0.4.4.20210116</version>
 		<packageSourceUrl>https://github.com/tricktux/choco-neovim</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
 		<owners>Reinaldo Molina</owners>

--- a/neovim/neovim.nuspec
+++ b/neovim/neovim.nuspec
@@ -73,8 +73,13 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
 ### Package Parametes
 - `/NoNeovimOnPath`: Neovim binary folder will not be added to the path.
 	- Optional parameter.
-	- Default behavior is that Neovim binary will be added to the path.
+	- Default behavior is that Neovim binary will be added to the users path.
 	- Example: `choco install neovim --params "/NoNeovimOnPath"`
+- `/AddToAllUserPath`: Neovim binary folder will be added to the machine path.
+	- Optional parameter.
+	- Default behavior is that Neovim binary will be added only to the users path.
+	- If this is used together with `/NoNeovimOnPath`, this takes precedence and the path will be modified.
+	- Example: `choco install neovim --params "/AddToAllUserPath"`
 
 **Note:** To force the installation of x32 version, use the --x86 argument with `choco install`.
 

--- a/neovim/tools/chocolateyinstall.ps1
+++ b/neovim/tools/chocolateyinstall.ps1
@@ -1,15 +1,16 @@
 ﻿# File:           chocolateyinstall.ps1
 # Description:    Installation of Neovim
-# Author:		    Reinaldo Molina
+# Author:         Reinaldo Molina
 # Email:          rmolin88 at gmail dot com
-# Revision:	    0.0.0
+# Revision:       0.0.0
 # Last Modified:  Fri Apr 20 2018 23:04
 
 $ErrorActionPreference = 'Stop'; # stop on all errors
-$packageName= 'neovim' # arbitrary name for the package, used in messages
-$destDir = Join-Path $(Get-ToolsLocation) $packageName
-$url        = 'https://github.com/neovim/neovim/releases/download/v0.4.4/nvim-win32.zip' # download url, HTTPS preferred
-$url64      = 'https://github.com/neovim/neovim/releases/download/v0.4.4/nvim-win64.zip' # 64bit URL here (HTTPS preferred) or remove - if installer contains both (very rare), use $url
+
+$packageName = 'neovim' # arbitrary name for the package, used in messages
+$destDir     = Join-Path $(Get-ToolsLocation) $packageName
+$url         = 'https://github.com/neovim/neovim/releases/download/v0.4.4/nvim-win32.zip' # download url, HTTPS preferred
+$url64       = 'https://github.com/neovim/neovim/releases/download/v0.4.4/nvim-win64.zip' # 64bit URL here (HTTPS preferred) or remove - if installer contains both (very rare), use $url
 $bin         = $destDir + '\Neovim\bin'
 
 # Get user provided paramaters
@@ -17,19 +18,19 @@ $bin         = $destDir + '\Neovim\bin'
 $pp = Get-PackageParameters
 
 $packageArgs = @{
-  packageName   = $packageName
-  unzipLocation = $destDir
-  url           = $url
-  url64bit      = $url64
+    packageName   = $packageName
+    unzipLocation = $destDir
+    url           = $url
+    url64bit      = $url64
 
-  softwareName  = 'neovim*' #part or all of the Display Name as you see it in Programs and Features. It should be enough to be unique
+    softwareName  = 'neovim*' #part or all of the Display Name as you see it in Programs and Features. It should be enough to be unique
 
-	checksum      = '2b8011cbe4a4028d8fddfecf555b5a66d05ad34d36e242ff26b418ddf33b323f'
-  checksumType  = 'sha256' #default is md5, can also be sha1, sha256 or sha512
-	checksum64    = '4b88daae8427624f82abb10eb6e527f4b0c600e83aaa9a0857d06106b445bbd3'
-  checksumType64= 'sha256' #default is checksumType
+    checksum      = '2b8011cbe4a4028d8fddfecf555b5a66d05ad34d36e242ff26b418ddf33b323f'
+    checksumType  = 'sha256' #default is md5, can also be sha1, sha256 or sha512
+    checksum64    = '4b88daae8427624f82abb10eb6e527f4b0c600e83aaa9a0857d06106b445bbd3'
+    checksumType64= 'sha256' #default is checksumType
 
-  validExitCodes= @(0) #please insert other valid exit codes here
+    validExitCodes= @(0) #please insert other valid exit codes here
 }
 
 # https://chocolatey.org/docs/helpers-install-chocolatey-package
@@ -37,14 +38,14 @@ Install-ChocolateyZipPackage @packageArgs
 
 # Adds neovim to the path if not present already
 # Define option here and check at the same time
-if ($pp['AddToAllUserPath']) {
-	Install-ChocolateyPath -PathToInstall $bin -PathType Machine
-        Write-Output "Added Neovim binary folder to the machines's PATH variable"
-} elseif (!$pp['NoNeovimOnPath']) {
-	Install-ChocolateyPath -PathToInstall $bin
-        Write-Output "Added Neovim binary folder to the user's PATH variable"
+if ($pp['NoNeovimOnPath']) {
+    Write-Output "Please note that Neovim binary folder will NOT be added to the path"
+} elseif (!$pp['NeovimOnPathForAll']) {
+    Install-ChocolateyPath -PathToInstall $bin -PathType Machine
+    Write-Output "Added Neovim binary folder to the machines's PATH variable"
 } else {
-        Write-Output "Please note that Neovim binary folder will NOT be added to the path"
+    Install-ChocolateyPath -PathToInstall $bin
+    Write-Output "Added Neovim binary folder to the user's PATH variable"
 }
 
 Write-Output "Please Consider donating https://salt.bountysource.com/teams/neovim"

--- a/neovim/tools/chocolateyinstall.ps1
+++ b/neovim/tools/chocolateyinstall.ps1
@@ -40,7 +40,7 @@ Install-ChocolateyZipPackage @packageArgs
 # Define option here and check at the same time
 if ($pp['NoNeovimOnPath']) {
     Write-Output "Please note that Neovim binary folder will NOT be added to the path"
-} elseif (!$pp['NeovimOnPathForAll']) {
+} elseif ($pp['NeovimOnPathForAll']) {
     Install-ChocolateyPath -PathToInstall $bin -PathType Machine
     Write-Output "Added Neovim binary folder to the machines's PATH variable"
 } else {

--- a/neovim/tools/chocolateyinstall.ps1
+++ b/neovim/tools/chocolateyinstall.ps1
@@ -40,7 +40,7 @@ Install-ChocolateyZipPackage @packageArgs
 if ($pp['AddToAllUserPath']) {
 	Install-ChocolateyPath -PathToInstall $bin -PathType Machine
         Write-Output "Added Neovim binary folder to the machines's PATH variable"
-} else if (!$pp['NoNeovimOnPath']) {
+} elseif (!$pp['NoNeovimOnPath']) {
 	Install-ChocolateyPath -PathToInstall $bin
         Write-Output "Added Neovim binary folder to the user's PATH variable"
 } else {

--- a/neovim/tools/chocolateyinstall.ps1
+++ b/neovim/tools/chocolateyinstall.ps1
@@ -37,10 +37,12 @@ Install-ChocolateyZipPackage @packageArgs
 
 # Adds neovim to the path if not present already
 # Define option here and check at the same time
-if (!$pp['NoNeovimOnPath']) {
+if ($pp['AddToAllUserPath']) {
+	Install-ChocolateyPath -PathToInstall $bin -PathType Machine
+        Write-Output "Added Neovim binary folder to the machines's PATH variable"
+} else if (!$pp['NoNeovimOnPath']) {
 	Install-ChocolateyPath -PathToInstall $bin
         Write-Output "Added Neovim binary folder to the user's PATH variable"
-
 } else {
         Write-Output "Please note that Neovim binary folder will NOT be added to the path"
 }

--- a/neovim/tools/chocolateyuninstall.ps1
+++ b/neovim/tools/chocolateyuninstall.ps1
@@ -9,4 +9,4 @@ $packageName= 'neovim' # arbitrary name for the package, used in messages
 $destDir = Join-Path $(Get-ToolsLocation) $packageName
 $bin         = $destDir + '\Neovim\bin'
 
-Write-Output "Please manually remove `"$($bin)`" from the User PATH environment variable if not installing neovim again."
+Write-Output "Please manually remove `"$($bin)`" from the PATH environment variable if not installing neovim again."


### PR DESCRIPTION
Added a package parameter to add the neovim path for ALL users (machine PATH) instead of just the current one.

This is needed to allow a proper "installation" of neovim, so that it is accessible for all users on a computer.

Use case: We need this parameter when installing neovim on servers as they are used by many people/users